### PR TITLE
Feature/12 メールのジョブの永続化を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,12 @@ gem 'carrierwave-i18n'
 # ページネーションを導入するために追加
 gem 'kaminari'
 
+gem 'sidekiq'
+
+
+# sidekiqのダッシュボードを利用するために、sinatraをいれる。
+gem 'sinatra'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ gem 'kaminari'
 
 gem 'sidekiq'
 
-
 # sidekiqのダッシュボードを利用するために、sinatraをいれる。
 gem 'sinatra'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       activesupport (>= 4.2)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-schema (~> 1.0)
+    connection_pool (2.2.2)
     crass (1.0.6)
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
@@ -191,6 +192,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (1.0.3)
     mysql2 (0.5.3)
     nio4r (2.5.4)
     nokogiri (1.10.10)
@@ -217,6 +219,8 @@ GEM
     public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.3)
+    rack-protection (2.0.7)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.4)
@@ -307,6 +311,16 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sidekiq (6.0.1)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
+    sinatra (2.0.7)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.7)
+      tilt (~> 2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -384,6 +398,8 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
+  sinatra
   slim-rails
   sorcery
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,9 @@ module InstaClone
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # active_jobで使用するデフォルトのアダプターを永続化のためにsidekiqにする。
+    config.active_job.queue_adapter = :sidekiq
   end
 end
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,4 +43,3 @@ module InstaClone
     config.active_job.queue_adapter = :sidekiq
   end
 end
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   # development環境の際にletter_operner_webを使用できるように追加
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  # mount Sidekiq::Web => '/sidekiq'と書くのと同じ様子
+  mount Sidekiq::Web, at: '/sidekiq'
   root 'posts#index'
 
   # セッション管理のルーティングを以下に記載。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 require 'sidekiq/web'
+# sessionの上書きをオフにする。(Ryoさんのslackをカンニングしました)
+Sidekiq::Web.set :sessions, false
 
 Rails.application.routes.draw do
   # development環境の際にletter_operner_webを使用できるように追加

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,6 @@
+# 同時処理できるプロセスを指定(マシンにもよるが50以下がいいらしい..)
+:concurrency: 25
+# Railsサーバーからmailersとういう名前のキューで送られるために指定。（これを書かないとbundle exec sidekiqの時に「-q mailers」の記載が必要）
+:queues:
+  - default
+  - mailers

--- a/note/12_install_sidekiq.md
+++ b/note/12_install_sidekiq.md
@@ -1,0 +1,47 @@
+# 12 メールのジョブの永続化を実装
+## そもそもメールのジョブの永続化とは？？(パRailsのP,240)
+Action Mailerのdeliver_laterメソッドは非同期送信をする時に内部でActive Job(非同期実行処理機能を提供するライブラリー)を使っている。  
+Active Jobの初期設定(asyncアダプター)では、Railsを再起動するとジョブが破棄されてしまう。  
+そのためにActive Jobのキューを永続化させる必要がある。
+
+## 永続化の方法
+■概要  
+Sidekiq、Resque、Delayed Jobなどを使って永続化をする。  
+(キューを貯めるNoSQLとしてRedisなどを使用する)
+
+■Sidekiqの場合のイメージ（間違えているかも...）  
+①メールjobのhttpリクエストをクライアントからRailsサーバーに依頼。  
+②Railsサーバーはメール処理については、Active Jobを経由してSidekiq&Redisにメール処理を依頼する。  
+③メール処理に関しては非同期でSidekiq&Redisが実行をする。
+
+## Sidekiqでの実装手順(現場RailsのP325)
+※パRailsではdockerを使っていたため参考にならず...  
+①gemを入れる。  
+②config/application.rbにアダプターの設定をする。
+```
+module ActiveJobExample
+  class Application < Rails::Application
+    略
+  config.active_job.queue_adapter = :sidekiq
+end
+```
+③`bundle exec sidekiq`でsidekiqを起動する。
+
+## ダッシュボードを利用する方法
+■概要  
+Sidekiqの現在の状態の管理画面を表示できるWebアプリケーション
+
+■実装方法  
+①shinatraのgemを入れる。
+
+②routes.rbにダッシュボードのルーティングを設定する。
+```rb
+require 'sidekiq/web'
+mount Sidekiq::Web => '/sidekiq'
+```
+
+③http://localhost:3000/sidekiq/で管理画面をみれる。
+
+■備考  
+パRailsのP,220にはSidekiq のAPIを直接使う方法もあると書いてあった。  
+Active Jobでは使えない機能が使えるようになるらしいが、Active JobをするAction Mailerなどは使えないらしい...


### PR DESCRIPTION
## 実施内容

* Sidekiq&RedisでActive Jobのキューを永続化する方法
* Sidekiqの状況をダッシュボードで確認する方法
[![Image from Gyazo](https://i.gyazo.com/78c37664928a1ba61491022e74badb98.png)](https://gyazo.com/78c37664928a1ba61491022e74badb98)

## 理解できた内容

* 永続化をするメリット

## さらに学習が必要な内容

* Active Jobを通さずにSidekiqを利用する方法
* Sidekiq以外での永続化の方法

## その他

* コード内のコメントに記載するには量が多くなってしまう内容については、noteディレクトリに学習内容の記載をしております。
* 回答例では、「config/sidekiq.rb」にredisのポート番号を指定しておりますが、デフォルトで'redis://localhost:6379'になるという記事を見ましたので、記載しておりません。(問題あればご指摘いただきたいです。)